### PR TITLE
메인프로젝트 - WebConfig 리팩토링

### DIFF
--- a/main-project-012/src/main/java/com/example/mainproject012/config/WebConfig.java
+++ b/main-project-012/src/main/java/com/example/mainproject012/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebFluxConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOriginPatterns("*")
                 .allowedMethods("GET", "POST", "PATCH", "DELETE")
                 .allowedHeaders("*")
                 .allowCredentials(true).maxAge(3600);


### PR DESCRIPTION
스프링 부트에서 CORS 설정 시
allowedOrigins("*")와 allowCredentials(true)를 
함께 사용할 수 없도록 업데이트 됨 따라서
allowedOrigins("*")  ->  allowedOriginPatterns("*")로 변경